### PR TITLE
Fix race condition when adding stars

### DIFF
--- a/starmanager/starmanager.go
+++ b/starmanager/starmanager.go
@@ -205,7 +205,6 @@ func (s *StarManager) starReposFromURLsChan(
 
 	wg := sync.WaitGroup{}
 	defer wg.Wait()
-
 	then := time.Now().AddDate(0, -notOlderThanMonths, 0)
 
 	for u := range urlsChan {
@@ -250,7 +249,6 @@ func (s *StarManager) starReposFromURLsChan(
 
 			wg.Add(1)
 			go func() { defer wg.Done(); successfulStars <- 1 }()
-			wg.Wait()
 		} else {
 			log.Infof(
 				"%s/%s does not qualify - archived: %t, pushed: %s\n",


### PR DESCRIPTION
Waiting on a waitgroup inside the loop when adding stars would get called multiple times, resulting in slow and eventual blockage.